### PR TITLE
Change events logic to be based on a class

### DIFF
--- a/src/app/api/events/route.test.ts
+++ b/src/app/api/events/route.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { DateTime } from 'luxon';
+import { GET } from './route';
+import { NextRequest } from 'next/server';
+
+describe('events route', () => {
+	test('works with valid parameters', async () => {
+		const request: NextRequest = new NextRequest('https://example.com/api/events?count=1&timezone=America/Los_Angeles&date=2023-01-01T00:00:00.000-08:00', {
+			method: 'GET',
+		});
+
+		const response = await GET(request);
+		expect(response.status).toBe(200);
+		expect(response.body).toBeDefined();
+
+		const data = await response.json();
+		expect(data).toBeInstanceOf(Array);
+		expect(data.length).toBe(1);
+	});
+
+	test('works with missing date', async () => {
+		const request: NextRequest = new NextRequest('https://example.com/api/events?count=1&timezone=America/Los_Angeles', {
+			method: 'GET',
+		});
+
+		const response = await GET(request);
+		expect(response.status).toBe(200);
+		expect(response.body).toBeDefined();
+
+		const data = await response.json();
+		expect(data).toBeInstanceOf(Array);
+		expect(data.length).toBe(1);
+	});
+
+	test('returns 400 with invalid date', async () => {
+		const request: NextRequest = new NextRequest('https://example.com/api/events?count=1&timezone=America/Los_Angeles&date=02-31-2025', {
+			method: 'GET',
+		});
+
+		const response = await GET(request);
+		expect(response.status).toBe(400);
+
+		const data = await response.text();
+		expect(data).toBe('this is not a valid date');
+	});
+
+	test('returns 400 when timezone is invalid', async () => {
+		const request: NextRequest = new NextRequest('https://example.com/api/events?count=1&timezone=invalid&date=2023-01-01T00:00:00.000-08:00', {
+			method: 'GET',
+		});
+
+		const response = await GET(request);
+		expect(response.status).toBe(400);
+
+		const data = await response.text();
+		expect(data).toBe('`timezone` must be a valid IANA timezone');
+	});
+
+	test('returns 400 when timezone is missing', async () => {
+		const request: NextRequest = new NextRequest('https://example.com/api/events?count=1&date=2023-01-01T00:00:00.000-08:00', {
+			method: 'GET',
+		});
+
+		const response = await GET(request);
+		expect(response.status).toBe(400);
+
+		const data = await response.text();
+		expect(data).toBe('`timezone` query parameter is required');
+	});
+
+	test('returns 400 when count is invalid', async () => {
+		const request: NextRequest = new NextRequest('https://example.com/api/events?count=-1&timezone=America/Los_Angeles&date=2023-01-01T00:00:00.000-08:00', {
+			method: 'GET',
+		});
+
+		const response = await GET(request);
+		expect(response.status).toBe(400);
+
+		const data = await response.text();
+		expect(data).toBe('`count` must not be negative');
+	});
+
+	test('returns 400 when count is missing', async () => {
+		const request: NextRequest = new NextRequest('https://example.com/api/events?timezone=America/Los_Angeles&date=2023-01-01T00:00:00.000-08:00', {
+			method: 'GET',
+		});
+
+		const response = await GET(request);
+		expect(response.status).toBe(400);
+
+		const data = await response.text();
+		expect(data).toBe('`count` query parameter is required');
+	});
+
+	test('returns 500 on unknown error', async () => {
+		vi.spyOn(DateTime, 'now').mockImplementation(() => {
+			throw new Error('Artificial error');
+		});
+		const request: NextRequest = new NextRequest('https://example.com/api/events?count=1&timezone=America/Los_Angeles', {
+			method: 'GET',
+		});
+
+		const response = await GET(request);
+		expect(response.status).toBe(500);
+
+		const data = await response.text();
+		expect(data).toBe('Unknown error');
+	});
+});

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -8,6 +8,7 @@ const countSchema = number().required('`count` query parameter is required').min
 const timezoneSchema = string()
 	.required('`timezone` query parameter is required')
 	.matches(/^[a-zA-Z0-9\/_+-]+\/[a-zA-Z0-9\/_+-]+$/, '`timezone` must be a valid IANA timezone');
+const manager = new EventsManager();
 
 export async function GET(request: NextRequest) {
 	let count;
@@ -32,7 +33,6 @@ export async function GET(request: NextRequest) {
 		}
 	}
 
-	const manager = new EventsManager();
 	// TODO: Add a timeout to keep the client from waiting forever
 	return Response.json(await manager.events(date, count));
 }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,13 +1,13 @@
 import { type NextRequest } from 'next/server';
 import { number, ValidationError, string } from 'yup';
-import { events } from '@/lib/events';
+import { EventsManager } from '@/lib/events';
 import { dateTimeSchema } from '@/lib/schemas';
 import { DateTime } from 'luxon';
 
 const countSchema = number().required('`count` query parameter is required').min(0, '`count` must not be negative');
 const timezoneSchema = string()
 	.required('`timezone` query parameter is required')
-	.matches(/^[a-zA-Z0-9\/_+-]+$/, '`timezone` must be a valid timezone');
+	.matches(/^[a-zA-Z0-9\/_+-]+\/[a-zA-Z0-9\/_+-]+$/, '`timezone` must be a valid IANA timezone');
 
 export async function GET(request: NextRequest) {
 	let count;
@@ -32,6 +32,7 @@ export async function GET(request: NextRequest) {
 		}
 	}
 
+	const manager = new EventsManager();
 	// TODO: Add a timeout to keep the client from waiting forever
-	return Response.json(await events(date, count));
+	return Response.json(await manager.events(date, count));
 }

--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -51,6 +51,11 @@ const biweeklyEventWithEndTimeYaml = `
 `;
 
 describe('events', () => {
+	test('fails if the data file is not found', async () => {
+		vi.stubEnv('DATA_FILE', 'data.yaml');
+		await expect(events(DateTime.fromISO('2022-01-01T00:00:00.000-08:00'), 1)).rejects.toThrow('Data file not found: data.yaml');
+	});
+
 	test('loads the example data when environment variable is unset', async () => {
 		vi.stubEnv('DATA_FILE', undefined);
 		vol.fromJSON({

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,16 +1,10 @@
 import { Event, Frequency, dataSchema } from './schemas';
+import { promises as fsp, watch } from 'fs';
 
 import { DateTime } from 'luxon';
 import { debounce } from './util';
-import { promises as fsp, watch, type FSWatcher } from 'fs';
 import { inPlaceSort } from 'fast-sort';
 import { parse as yamlParse } from 'yaml';
-
-let INITIALIZED = false;
-let CACHED_RESULTS: { [key: string]: [Event[], AsyncGenerator<Event, void, unknown>] } = {};
-let PARSED_EVENTS: Promise<Event[]> = Promise.resolve([]);
-let DATA_FILE: Promise<fsp.FileHandle> | undefined = undefined;
-let WATCHER: FSWatcher | undefined = undefined;
 
 export interface EventSummary {
 	name: string;
@@ -21,40 +15,48 @@ export interface EventSummary {
 	tags: string[];
 }
 
-function init() {
-	const DATA_FILENAME = process.env.DATA_FILE ?? 'example/data.yaml';
+export class EventsManager {
+	private cachedResults: { [key: string]: [Event[], AsyncGenerator<Event, void, unknown>] } = {};
+	private parsedEvents: Promise<Event[]> = Promise.resolve([]);
+	private dataFile: Promise<fsp.FileHandle> | undefined = undefined;
 
-	if (INITIALIZED) throw new Error('Already initialized - `init` should only be called once');
+	constructor() {
+		const dataFilename = process.env.DATA_FILE ?? 'example/data.yaml';
 
-	const debouncedParse = debounce(() => {
-		CACHED_RESULTS = {};
-		PARSED_EVENTS = parseEvents();
-	}, 500);
+		const debouncedParse = debounce(() => {
+			this.cachedResults = {};
+			this.parsedEvents = this.parseEvents();
+		}, 500);
 
-	console.log(`Using data file: ${DATA_FILENAME}`);
+		console.log(`Initializing ${EventsManager.name} using data file: ${dataFilename}`);
 
-	// Open the data file and start watching it (we watch the file only after opening it to ensure it exists)
-	DATA_FILE = fsp
-		.open(DATA_FILENAME)
-		.then(file => {
-			// When the data file changes, we parse it again and clear the old cache
-			WATCHER = watch(DATA_FILENAME, eventType => {
-				console.log(`Data file changed (${eventType})`);
-				if (eventType === 'change') debouncedParse();
+		// Open the data file and start watching it (we watch the file only after opening it to ensure it exists)
+		this.dataFile = fsp
+			.open(dataFilename)
+			.then(file => {
+				// When the data file changes, we parse it again and clear the old cache
+				watch(dataFilename, eventType => {
+					console.log(`Data file changed (${eventType})`);
+					if (eventType === 'change') debouncedParse();
+				});
+				return file;
+			})
+			.catch(() => {
+				throw new Error(`Data file not found: ${dataFilename}`);
 			});
-			return file;
-		})
-		.catch(() => {
-			throw new Error(`Data file not found: ${DATA_FILENAME}`);
-		});
 
-	// TODO: Make this first call lazy
-	PARSED_EVENTS = parseEvents();
+		// TODO: Make this first call lazy
+		this.parsedEvents = this.parseEvents();
+	}
 
-	INITIALIZED = true;
+	async events(from: DateTime, count: number): Promise<[string, EventSummary[]][]> {
+		const events = await this.enumerateEvents(from, count);
+		const groups = this.groupAndCleanEvents(events);
+		return groups;
+	}
 
-	async function parseEvents() {
-		const file = await DATA_FILE!.catch(error => {
+	private async parseEvents(): Promise<Event[]> {
+		const file = await this.dataFile!.catch(error => {
 			console.log('Error opening data file');
 			console.log(error);
 			throw error;
@@ -65,156 +67,126 @@ function init() {
 		});
 
 		const events = dataSchema.validateSync(yamlParse(eventDataFileContent)).upcoming;
-		sortEvents(events);
+		this.sortEvents(events);
 
 		console.log('Events parsed');
 		return events;
 	}
-}
 
-export function reset() {
-	if (process.env.NODE_ENV !== 'test') throw new Error('reset should only be called in test environment');
+	private sortEvents(events: Event[]): void {
+		// Sort the events so that the earliest ones come first (null represents "immediate" TODOs and so should come first)
+		inPlaceSort(events).asc(e => e.start?.valueOf() ?? -1);
+	}
 
-	if (!INITIALIZED) return;
+	private async *enumerateEventsFromDate(date: DateTime) {
+		// Clone the parsed events data so we can modify it
+		const events = (await this.parsedEvents).slice();
 
-	INITIALIZED = false;
-	CACHED_RESULTS = {};
-	PARSED_EVENTS = Promise.resolve([]);
-	WATCHER?.close();
-	WATCHER = undefined;
-	DATA_FILE?.then(file => file.close()).catch(error => {
-		// Ignore EBADF errors since I don't know how to avoid them
-		if ('code' in error && error.code === 'EBADF') return;
-		throw error;
-	});
-	DATA_FILE = undefined;
+		while (events.length) {
+			const event = events.shift() as Event;
 
-	// console.log was spied on in the test file
-	console.log('Reset');
-}
-
-function sortEvents(events: Event[]) {
-	// Sort the events so that the earliest ones come first (null represents "immediate" TODOs and so should come first)
-	inPlaceSort(events).asc(e => e.start?.valueOf() ?? -1);
-}
-
-async function* enumerateEventsFromDate(date: DateTime) {
-	// Clone the parsed events data so we can modify it
-	const events = (await PARSED_EVENTS).slice();
-
-	while (events.length) {
-		const event = events.shift() as Event;
-
-		// Add a new event to the list if this event is repeating
-		if (event.frequency !== Frequency.Once) {
-			// The schema ensures that any event with a frequency other than "once" has a start date
-			if (event.frequency === Frequency.Weekly) {
-				const nextEvent = { ...event, start: event.start!.plus({ weeks: 1 }), end: event.end ? event.end.plus({ weeks: 1 }) : event.end };
-				events.push(nextEvent);
-			} else if (event.frequency === Frequency.Biweekly) {
-				const nextEvent = { ...event, start: event.start!.plus({ weeks: 2 }), end: event.end ? event.end.plus({ weeks: 2 }) : event.end };
-				events.push(nextEvent);
-			} else if (event.frequency === Frequency.Weekdays) {
-				let daysToAdd = 1;
-				let nextDay = event.start!.plus({ days: daysToAdd });
-				while (nextDay.isWeekend) {
-					nextDay = event.start!.plus({ days: ++daysToAdd });
+			// Add a new event to the list if this event is repeating
+			if (event.frequency !== Frequency.Once) {
+				// The schema ensures that any event with a frequency other than "once" has a start date
+				if (event.frequency === Frequency.Weekly) {
+					const nextEvent = { ...event, start: event.start!.plus({ weeks: 1 }), end: event.end ? event.end.plus({ weeks: 1 }) : event.end };
+					events.push(nextEvent);
+				} else if (event.frequency === Frequency.Biweekly) {
+					const nextEvent = { ...event, start: event.start!.plus({ weeks: 2 }), end: event.end ? event.end.plus({ weeks: 2 }) : event.end };
+					events.push(nextEvent);
+				} else if (event.frequency === Frequency.Weekdays) {
+					let daysToAdd = 1;
+					let nextDay = event.start!.plus({ days: daysToAdd });
+					while (nextDay.isWeekend) {
+						nextDay = event.start!.plus({ days: ++daysToAdd });
+					}
+					const nextEvent = { ...event, start: nextDay, end: event.end ? event.end.plus({ days: daysToAdd }) : event.end };
+					events.push(nextEvent);
 				}
-				const nextEvent = { ...event, start: nextDay, end: event.end ? event.end.plus({ days: daysToAdd }) : event.end };
-				events.push(nextEvent);
+
+				// Sort the events after adding a new one
+				this.sortEvents(events);
 			}
 
-			// Sort the events after adding a new one
-			sortEvents(events);
-		}
+			// Skip events that have already occurred
+			if (event.start && event.start < date) {
+				continue;
+			}
 
-		// Skip events that have already occurred
-		if (event.start && event.start < date) {
-			continue;
-		}
+			// Add a new event for events that span multiple days
+			if (event.end && event.end.day > event.start!.day) {
+				// The schema ensures that any event with an end date has a start date
+				const nextEvent = { ...event, start: event.start!.plus({ days: 1 }) };
+				events.push(nextEvent);
 
-		// Add a new event for events that span multiple days
-		if (event.end && event.end.day > event.start!.day) {
-			// The schema ensures that any event with an end date has a start date
-			const nextEvent = { ...event, start: event.start!.plus({ days: 1 }) };
-			events.push(nextEvent);
+				// Sort the events after adding a new one
+				this.sortEvents(events);
+			}
 
-			// Sort the events after adding a new one
-			sortEvents(events);
-		}
-
-		// Return valid upcoming events
-		if (event.start === null || event.start > date) {
-			yield event;
+			// Return valid upcoming events
+			if (event.start === null || event.start > date) {
+				yield event;
+			}
 		}
 	}
-}
 
-function toDateString(date: DateTime) {
-	// The client expects dates in a form like "Wed Mar 19 2025" since that's what `Date.toDateString` outputs
-	return date.toFormat('ccc LLL dd yyyy');
-}
-
-async function enumerateEvents(from: DateTime, count: number): Promise<Event[]> {
-	// The key for the cache is the date without the time
-	const cacheKey = toDateString(from);
-
-	// Initialize the cache if it didn't already exist
-	if (!CACHED_RESULTS[cacheKey]) CACHED_RESULTS[cacheKey] = [[], enumerateEventsFromDate(from)];
-
-	// If we already have enough results, return them
-	if (CACHED_RESULTS[cacheKey][0].length >= count) return CACHED_RESULTS[cacheKey][0].slice(0, count);
-
-	// Otherwise, keep generating events until we have enough
-	while (CACHED_RESULTS[cacheKey][0].length < count) {
-		const nextEvent = await CACHED_RESULTS[cacheKey][1].next();
-		if (nextEvent.done) {
-			break;
-		}
-		CACHED_RESULTS[cacheKey][0].push(nextEvent.value);
+	private toDateString(date: DateTime): string {
+		// The client expects dates in a form like "Wed Mar 19 2025" since that's what `Date.toDateString` outputs
+		return date.toFormat('ccc LLL dd yyyy');
 	}
 
-	return CACHED_RESULTS[cacheKey][0];
-}
+	private async enumerateEvents(from: DateTime, count: number): Promise<Event[]> {
+		// The key for the cache is the date without the time
+		const cacheKey = this.toDateString(from);
 
-function groupAndCleanEvents(events: Event[]) {
-	// The client prints the times as is, so formatting is left to the server
-	const getTime = (date: DateTime) =>
-		date.toLocaleString({
-			hour: 'numeric',
-			minute: 'numeric',
-			hour12: true,
-			timeZoneName: 'shortGeneric',
+		// Initialize the cache if it didn't already exist
+		if (!this.cachedResults[cacheKey]) this.cachedResults[cacheKey] = [[], this.enumerateEventsFromDate(from)];
+
+		// If we already have enough results, return them
+		if (this.cachedResults[cacheKey][0].length >= count) return this.cachedResults[cacheKey][0].slice(0, count);
+
+		// Otherwise, keep generating events until we have enough
+		while (this.cachedResults[cacheKey][0].length < count) {
+			const nextEvent = await this.cachedResults[cacheKey][1].next();
+			if (nextEvent.done) {
+				break;
+			}
+			this.cachedResults[cacheKey][0].push(nextEvent.value);
+		}
+
+		return this.cachedResults[cacheKey][0];
+	}
+
+	private groupAndCleanEvents(events: Event[]): [string, EventSummary[]][] {
+		// The client prints the times as is, so formatting is left to the server
+		const getTime = (date: DateTime) =>
+			date.toLocaleString({
+				hour: 'numeric',
+				minute: 'numeric',
+				hour12: true,
+				timeZoneName: 'shortGeneric',
+			});
+
+		const groups: { [key: string]: EventSummary[] } = {};
+
+		for (const event of events) {
+			const key = event.start ? this.toDateString(event.start) : 'TODO';
+			if (!groups[key]) groups[key] = [];
+			groups[key].push({
+				name: event.name,
+				priority: event.priority,
+				location: event.location,
+				startTime: event.start && (event.start.hour !== 0 || event.start.minute !== 0) ? getTime(event.start!) : undefined,
+				endTime: event.end && (event.end.hour !== 0 || event.end.minute !== 0) ? getTime(event.end!) : undefined,
+				tags: event.tags,
+			});
+		}
+
+		const results: [string, EventSummary[]][] = Object.keys(groups).map(key => {
+			inPlaceSort(groups[key]).desc(e => e.priority);
+			return [key, groups[key]];
 		});
-
-	const groups: { [key: string]: EventSummary[] } = {};
-
-	for (const event of events) {
-		const key = event.start ? toDateString(event.start) : 'TODO';
-		if (!groups[key]) groups[key] = [];
-		groups[key].push({
-			name: event.name,
-			priority: event.priority,
-			location: event.location,
-			startTime: event.start && (event.start.hour !== 0 || event.start.minute !== 0) ? getTime(event.start!) : undefined,
-			endTime: event.end && (event.end.hour !== 0 || event.end.minute !== 0) ? getTime(event.end!) : undefined,
-			tags: event.tags,
-		});
+		inPlaceSort(results).asc([([key]) => new Date(key === 'TODO' ? '1970-01-01' : key)]);
+		return results;
 	}
-
-	const results: [string, EventSummary[]][] = Object.keys(groups).map(key => {
-		inPlaceSort(groups[key]).desc(e => e.priority);
-		return [key, groups[key]];
-	});
-	inPlaceSort(results).asc([([key]) => new Date(key === 'TODO' ? '1970-01-01' : key)]);
-	return results;
-}
-
-export async function events(from: DateTime, count: number): Promise<[string, EventSummary[]][]> {
-	if (!INITIALIZED) init();
-	else console.log('Already initialized');
-
-	const events = await enumerateEvents(from, count);
-	const groups = groupAndCleanEvents(events);
-	return groups;
 }


### PR DESCRIPTION
This removes the need for complex `init` and `reset` logic to handle global variables. That pattern of handling state was awkward at best. This change should make it easier to add support for programmatically adding events to the data file.

This also adds tests for the api route that is backed by the events logic.